### PR TITLE
url validator should allow colon in path

### DIFF
--- a/src/app/services/validation.service.ts
+++ b/src/app/services/validation.service.ts
@@ -1,7 +1,7 @@
 import {Component, Input} from '@angular/core';
 import {FormGroup, FormControl, AbstractControl} from '@angular/forms';
 
-export const urlregex = /^(?:https?:\/\/)(?:([\w\._-]+)(\.[\w\._-]+)+(:\d+)?)(?:(\/[\w\._-]+))*$/;
+export const urlregex = /^(?:https?:\/\/)(?:([\w\._-]+)(\.[\w\._-]+)+(:\d+)?)(?:(\/[\w\.\:_-]+))*$/;
 export const gitregex = [
     /^(https?:\/\/)(?:([\w\._-]+)(\.[\w\._-]+)+(:\d+)?)(?:(\/[\w\._~-]+))+$/,
     /^(ssh:\/\/)?(\w+@)?(?:([\w\._-]+)(\.[\w\._-]+)+(:\d+)?)[:/][\w\._~-]+(\/[\w\._-]+)+$/,


### PR DESCRIPTION
Some public package repos have colons in url, e.g. https://pkgs.k8s.io/core:/stable:/v1.29/deb/